### PR TITLE
feat: add total bonus (power) display to all cards

### DIFF
--- a/components/CardsDashboard.tsx
+++ b/components/CardsDashboard.tsx
@@ -16,6 +16,7 @@ interface CardData {
   rarityTyped: string;
   anyPositions?: string[];
   pictureUrl?: string;
+  power?: string;
   l5Average?: number;
   l10Average?: number;
   l15Average?: number;
@@ -122,6 +123,7 @@ export function CardsDashboard() {
                       rarityTyped
                       anyPositions
                       pictureUrl
+                      power
                       l5Average: averageScore(type: LAST_FIVE_SO5_AVERAGE_SCORE)
                       l10Average: averageScore(type: LAST_TEN_PLAYED_SO5_AVERAGE_SCORE)
                       l15Average: averageScore(type: LAST_FIFTEEN_SO5_AVERAGE_SCORE)
@@ -371,6 +373,12 @@ export function CardsDashboard() {
                       {card.anyPositions && card.anyPositions.length > 0 && (
                         <div className="text-sm">
                           <span className="font-medium">Position:</span> {card.anyPositions.join(', ')}
+                        </div>
+                      )}
+                      {/* Total Bonus (Power) */}
+                      {card.power && (
+                        <div className="text-sm bg-primary/10 p-2 rounded-md text-center">
+                          <span className="font-medium">Total Bonus:</span> <span className="font-bold">{card.power}</span>
                         </div>
                       )}
                       {/* Averages */}

--- a/lib/graphql/queries.ts
+++ b/lib/graphql/queries.ts
@@ -14,6 +14,7 @@ export const GET_CARDS_QUERY = `
           rarityTyped
           anyPositions
           pictureUrl
+          power
           l5Average: averageScore(type: LAST_FIVE_SO5_AVERAGE_SCORE)
           l10Average: averageScore(type: LAST_TEN_PLAYED_SO5_AVERAGE_SCORE)
           l15Average: averageScore(type: LAST_FIFTEEN_SO5_AVERAGE_SCORE)
@@ -41,6 +42,7 @@ export type GetCardsQueryResponse = {
         rarityTyped: string;
         anyPositions?: string[];
         pictureUrl?: string;
+        power?: string;
         l5Average?: number;
         l10Average?: number;
         l15Average?: number;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -32,6 +32,7 @@ export interface Card {
   rarityTyped: string;
   anyPositions?: string[];
   pictureUrl?: string;
+  power?: string;
   l5Average?: number;
   l10Average?: number;
   l15Average?: number;


### PR DESCRIPTION
This PR adds the display of total bonus (power: XP + Season bonus) for each card in all views.

## Changes
- Added `power` field to TypeScript Card interface
- Updated GraphQL queries to fetch the power field
- Added highlighted UI section to display total bonus on each card

Closes #2

Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/loziobiz/sorare-ai/actions/runs/20623566252