### PR TITLE
Fix column scrolling and optimize lineup builder UI

### DIFF
--- a/components/lineup/lineup-builder.tsx
+++ b/components/lineup/lineup-builder.tsx
@@ -509,9 +509,9 @@ export function LineupBuilder() {
       />
       <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:gap-6">
         {/* Sezione sinistra - Campo di calcio */}
-        <div className="flex flex-col lg:sticky lg:top-4 lg:w-[520px]">
+        <div className="flex max-h-[calc(100vh-8rem)] flex-col overflow-y-auto lg:w-[420px]">
           {/* Nome formazione */}
-          <div className="mb-4">
+          <div className="mb-3">
             <label
               className="mb-2 block font-medium text-sm"
               htmlFor="formation-name"
@@ -519,7 +519,7 @@ export function LineupBuilder() {
               Nome formazione
             </label>
             <Input
-              className="h-11"
+              className="h-9"
               id="formation-name"
               onChange={(e) => setFormationName(e.target.value)}
               placeholder="Nome formazione (obbligatorio)"
@@ -528,8 +528,27 @@ export function LineupBuilder() {
             />
           </div>
 
+          {/* Bottone conferma */}
+          <Button
+            className="mb-3 h-12 gap-2 bg-violet-600 font-semibold text-base hover:bg-violet-700"
+            disabled={
+              !formationName.trim() ||
+              formation.filter((s) => s.card).length < 5
+            }
+            onClick={handleConfirmFormation}
+          >
+            <Check className="h-5 w-5" />
+            {editingId ? "Aggiorna formazione" : "Salva formazione"}
+          </Button>
+
+          {error && (
+            <Alert className="mb-3" variant="destructive">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+
           {/* Campo di calcio */}
-          <div className="relative flex aspect-[7/8] flex-col overflow-hidden rounded-2xl bg-gradient-to-b from-emerald-600 to-emerald-700 shadow-xl">
+          <div className="relative flex aspect-[7/8] flex-col overflow-hidden rounded-xl bg-gradient-to-b from-emerald-600 to-emerald-700 shadow-lg">
             {/* Linee del campo */}
             <div className="absolute inset-5 rounded-lg border-2 border-white/30" />
             <div className="absolute top-1/2 right-5 left-5 h-0.5 -translate-y-1/2 bg-white/30" />
@@ -538,7 +557,7 @@ export function LineupBuilder() {
             <div className="absolute top-5 left-1/2 h-24 w-40 -translate-x-1/2 border-2 border-white/30 border-t-0" />
 
             {/* Slot posizioni */}
-            <div className="relative z-10 flex h-full flex-col justify-between gap-3 px-6 py-4">
+            <div className="relative z-10 flex h-full flex-col justify-between gap-2 px-4 py-3">
               {/* Riga alta - ATT ed EX */}
               <div className="flex justify-around">
                 <PitchSlot
@@ -592,29 +611,10 @@ export function LineupBuilder() {
               </div>
             </div>
           </div>
-
-          {/* Bottone conferma */}
-          <Button
-            className="mt-4 h-14 gap-2 bg-violet-600 font-semibold text-lg hover:bg-violet-700"
-            disabled={
-              !formationName.trim() ||
-              formation.filter((s) => s.card).length < 5
-            }
-            onClick={handleConfirmFormation}
-          >
-            <Check className="h-5 w-5" />
-            {editingId ? "Aggiorna formazione" : "Salva formazione"}
-          </Button>
-
-          {error && (
-            <Alert className="mt-4" variant="destructive">
-              <AlertDescription>{error}</AlertDescription>
-            </Alert>
-          )}
         </div>
 
         {/* Sezione destra - Collezione carte */}
-        <div className="flex-1">
+        <div className="flex max-h-[calc(100vh-8rem)] flex-1 flex-col overflow-y-auto">
           {/* Header selezione */}
           <div className="mb-4 flex items-center justify-between">
             <h2 className="font-bold text-slate-800 text-xl">

--- a/components/lineup/pitch-slot.tsx
+++ b/components/lineup/pitch-slot.tsx
@@ -31,14 +31,14 @@ export function PitchSlot({ label, card, isActive, onClick }: PitchSlotProps) {
         {card.pictureUrl ? (
           <Image
             alt={card.name}
-            className="h-49 w-30 rounded-lg object-cover shadow-lg"
-            height={176}
+            className="h-36 w-24 rounded-lg object-cover shadow-lg"
+            height={144}
             src={card.pictureUrl}
             unoptimized
-            width={128}
+            width={96}
           />
         ) : (
-          <div className="flex h-44 w-32 items-center justify-center rounded-lg bg-slate-700 font-bold text-2xl text-white shadow-lg">
+          <div className="flex h-36 w-24 items-center justify-center rounded-lg bg-slate-700 font-bold text-xl text-white shadow-lg">
             {card.name.charAt(0)}
           </div>
         )}
@@ -59,7 +59,7 @@ export function PitchSlot({ label, card, isActive, onClick }: PitchSlotProps) {
     >
       <div
         className={cn(
-          "flex h-44 w-32 flex-col items-center justify-center rounded-xl border-2 border-dashed transition-all",
+          "flex h-36 w-24 flex-col items-center justify-center rounded-xl border-2 border-dashed transition-all",
           isActive
             ? "border-violet-400 bg-violet-500/20"
             : "border-white/40 bg-white/10 hover:border-white/60 hover:bg-white/20"
@@ -67,7 +67,7 @@ export function PitchSlot({ label, card, isActive, onClick }: PitchSlotProps) {
       >
         <span
           className={cn(
-            "mb-3 font-semibold text-base",
+            "mb-2 font-semibold text-sm",
             isActive ? "text-violet-200" : "text-white/70"
           )}
         >
@@ -75,13 +75,13 @@ export function PitchSlot({ label, card, isActive, onClick }: PitchSlotProps) {
         </span>
         <div
           className={cn(
-            "flex h-12 w-12 items-center justify-center rounded-full border-2 border-dashed transition-colors",
+            "flex h-10 w-10 items-center justify-center rounded-full border-2 border-dashed transition-colors",
             isActive
               ? "border-violet-300 text-violet-200"
               : "border-white/40 text-white/50 group-hover:border-white/60"
           )}
         >
-          <Plus className="h-6 w-6" />
+          <Plus className="h-5 w-5" />
         </div>
       </div>
     </button>


### PR DESCRIPTION
## Changes

- Remove sticky positioning from left column to enable independent scrolling
- Add max-height and overflow-y-auto to both columns for independent scroll
- Reduce left column width from 520px to 420px
- Move save/update button to top of left column for better accessibility
- Reduce card sizes in pitch slots for more compact layout
- Optimize spacing and sizing throughout the UI

Fixes #10

---

Generated with [Claude Code](https://claude.ai/code)