### PR TITLE
feat: add search filter to cards page

### DIFF
--- a/components/cards-dashboard.tsx
+++ b/components/cards-dashboard.tsx
@@ -30,6 +30,7 @@ export function CardsDashboard() {
     setSortBy,
     setInSeasonOnly,
     setSealed,
+    setSearchQuery,
     leagues,
     filteredCards,
   } = useCardFilters(cards);
@@ -72,10 +73,12 @@ export function CardsDashboard() {
         onPositionChange={setPosition}
         onRarityChange={setRarity}
         onSealedChange={setSealed}
+        onSearchQueryChange={setSearchQuery}
         onSortChange={setSortBy}
         position={filters.position}
         rarity={filters.rarity}
         sealed={filters.sealed}
+        searchQuery={filters.searchQuery}
         sortBy={filters.sortBy}
       />
 

--- a/components/cards/cards-filters.tsx
+++ b/components/cards/cards-filters.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { Search } from "lucide-react";
 import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
 import {
   getPositionLabel,
   type LeagueOption,
@@ -17,6 +19,7 @@ interface CardsFiltersProps {
   sortBy: SortOption;
   inSeasonOnly: boolean;
   sealed: SealedFilter;
+  searchQuery: string;
   leagues: LeagueOption[];
   onRarityChange: (rarity: RarityFilter) => void;
   onPositionChange: (position: PositionFilter) => void;
@@ -24,6 +27,7 @@ interface CardsFiltersProps {
   onSortChange: (sortBy: SortOption) => void;
   onInSeasonChange: (inSeasonOnly: boolean) => void;
   onSealedChange: (sealed: SealedFilter) => void;
+  onSearchQueryChange: (searchQuery: string) => void;
 }
 
 const SELECT_CLASS =
@@ -36,6 +40,7 @@ export function CardsFilters({
   sortBy,
   inSeasonOnly,
   sealed,
+  searchQuery,
   leagues,
   onRarityChange,
   onPositionChange,
@@ -43,6 +48,7 @@ export function CardsFilters({
   onSortChange,
   onInSeasonChange,
   onSealedChange,
+  onSearchQueryChange,
 }: CardsFiltersProps) {
   return (
     <div className="flex flex-wrap items-center gap-4">
@@ -56,6 +62,7 @@ export function CardsFilters({
       <SortSelect onChange={onSortChange} value={sortBy} />
       <SealedSelect onChange={onSealedChange} value={sealed} />
       <InSeasonCheckbox checked={inSeasonOnly} onChange={onInSeasonChange} />
+      <SearchInput onChange={onSearchQueryChange} value={searchQuery} />
     </div>
   );
 }
@@ -212,6 +219,25 @@ function SealedSelect({ value, onChange }: SealedSelectProps) {
         <option value="sealed">Cassaforte</option>
         <option value="all">Tutte</option>
       </select>
+    </div>
+  );
+}
+
+interface SearchInputProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+function SearchInput({ value, onChange }: SearchInputProps) {
+  return (
+    <div className="relative min-w-[200px] flex-1">
+      <Search className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-slate-400" />
+      <Input
+        className="h-9 pl-10"
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="Cerca giocatore o squadra..."
+        value={value}
+      />
     </div>
   );
 }

--- a/hooks/use-card-filters.ts
+++ b/hooks/use-card-filters.ts
@@ -21,6 +21,7 @@ interface UseCardFiltersReturn {
   setSortBy: (sortBy: SortOption) => void;
   setInSeasonOnly: (inSeasonOnly: boolean) => void;
   setSealed: (sealed: SealedFilter) => void;
+  setSearchQuery: (searchQuery: string) => void;
   leagues: LeagueOption[];
   filteredCards: CardData[];
 }
@@ -32,6 +33,7 @@ export function useCardFilters(cards: CardData[]): UseCardFiltersReturn {
   const [sortBy, setSortBy] = useState<SortOption>("name");
   const [inSeasonOnly, setInSeasonOnly] = useState(false);
   const [sealed, setSealed] = useState<SealedFilter>("unsealed");
+  const [searchQuery, setSearchQuery] = useState<string>("");
 
   const filters: CardFilters = useMemo(
     () => ({
@@ -41,8 +43,9 @@ export function useCardFilters(cards: CardData[]): UseCardFiltersReturn {
       sortBy,
       inSeasonOnly,
       sealed,
+      searchQuery,
     }),
-    [rarity, position, league, sortBy, inSeasonOnly, sealed]
+    [rarity, position, league, sortBy, inSeasonOnly, sealed, searchQuery]
   );
 
   const leagues = useMemo(() => extractLeagues(cards), [cards]);
@@ -60,6 +63,7 @@ export function useCardFilters(cards: CardData[]): UseCardFiltersReturn {
     setSortBy,
     setInSeasonOnly,
     setSealed,
+    setSearchQuery,
     leagues,
     filteredCards,
   };

--- a/lib/cards-utils.ts
+++ b/lib/cards-utils.ts
@@ -149,6 +149,22 @@ function filterBySealed(cards: CardData[], sealed: SealedFilter): CardData[] {
 }
 
 /**
+ * Filter cards by search query (name and team)
+ */
+function filterBySearch(cards: CardData[], searchQuery: string): CardData[] {
+  if (!searchQuery.trim()) {
+    return cards;
+  }
+
+  const query = searchQuery.toLowerCase().trim();
+  return cards.filter(
+    (card) =>
+      card.name.toLowerCase().includes(query) ||
+      card.anyPlayer?.activeClub?.name?.toLowerCase().includes(query)
+  );
+}
+
+/**
  * Sort cards by the specified option
  */
 function sortCards(cards: CardData[], sortBy: SortOption): CardData[] {
@@ -181,6 +197,7 @@ export interface CardFilters {
   sortBy: SortOption;
   inSeasonOnly: boolean;
   sealed: SealedFilter;
+  searchQuery: string;
 }
 
 /**
@@ -195,5 +212,6 @@ export function filterAndSortCards(
   result = filterByLeague(result, filters.league);
   result = filterByInSeason(result, filters.inSeasonOnly);
   result = filterBySealed(result, filters.sealed);
+  result = filterBySearch(result, filters.searchQuery);
   return sortCards(result, filters.sortBy);
 }


### PR DESCRIPTION
Add search functionality to filter cards by player name and team name.

Closes #7

🤖 Generated with [Claude Code](https://claude.ai/code)