### PR TITLE
feat: set list view as default for cards and lineup

### DIFF
--- a/components/cards-dashboard.tsx
+++ b/components/cards-dashboard.tsx
@@ -19,7 +19,7 @@ import { useCardFilters } from "@/hooks/use-card-filters";
 import { useCards } from "@/hooks/use-cards";
 
 export function CardsDashboard() {
-  const [viewMode, setViewMode] = useState<ViewMode>("grid");
+  const [viewMode, setViewMode] = useState<ViewMode>("list");
   const [tableSortKey, setTableSortKey] = useState<SortKey>("name");
   const [tableSortDirection, setTableSortDirection] =
     useState<SortDirection>("asc");

--- a/components/lineup/lineup-builder.tsx
+++ b/components/lineup/lineup-builder.tsx
@@ -196,7 +196,7 @@ export function LineupBuilder() {
   const [inSeasonOnly, setInSeasonOnly] = useState(false);
   const [formationName, setFormationName] = useState("");
   const [editingId, setEditingId] = useState<number | null>(null);
-  const [viewMode, setViewMode] = useState<ViewMode>("grid");
+  const [viewMode, setViewMode] = useState<ViewMode>("list");
   const [tableSortKey, setTableSortKey] = useState<SortKey>("name");
   const [tableSortDirection, setTableSortDirection] =
     useState<SortDirection>("asc");


### PR DESCRIPTION
Imposta la vista a lista come default per le pagine /cards e /lineup invece della vista a griglia.

La pagina /lineup aveva già la vista a lista implementata dal lavoro precedente.

Modifiche:
- components/cards-dashboard.tsx: default ViewMode = "list"
- components/lineup/lineup-builder.tsx: default ViewMode = "list"

Resolves #8

Generated with [Claude Code](https://claude.ai/code)